### PR TITLE
Fix deprecated '${var}, convert  to '{$var}'

### DIFF
--- a/resources/db_query.php
+++ b/resources/db_query.php
@@ -64,13 +64,13 @@ function open_db() {
     if (file_exists($filename)) {
         $a_configs = parse_ini_file($filename);
     } else {
-        print_debug_as_html_paragraph("Could not find file ${filename}");
+        print_debug_as_html_paragraph("Could not find file {$filename}");
         return FALSE;
     }
     if (!isset($a_configs["host"]) ||
         !isset($a_configs["user"]) ||
         !isset($a_configs["password"])) {
-        print_debug_as_html_paragraph("Undefined host, user, and password in ${filename}");
+        print_debug_as_html_paragraph("Undefined host, user, and password in {$filename}");
         return FALSE;
     }
 
@@ -82,7 +82,7 @@ function open_db() {
     try {
         $mysqli = mysqli_connect($a_configs["host"], $a_configs["user"], $a_configs["password"]);
     } catch (Exception $e) {
-        print_debug_as_html_paragraph("Unable to connect to MySQL. ${e}");
+        print_debug_as_html_paragraph("Unable to connect to MySQL. {$e}");
         return FALSE;
     }
     if ($mysqli->connect_errno) {

--- a/resources/debug.php
+++ b/resources/debug.php
@@ -1,7 +1,7 @@
 <?php
 
 function print_debug_as_html_paragraph($s_value) {
-    echo "DEBUG: <p>${s_value}</p>";
+    echo "DEBUG: <p>{$s_value}</p>";
 }
 
 ?>

--- a/resources/globals.php
+++ b/resources/globals.php
@@ -31,7 +31,7 @@ function define_global_vars() {
     if (file_exists($filename)) {
         $a_configs = parse_ini_file($filename);
     } else {
-        print_debug_as_html_paragraph("Could not find ${filename}");
+        print_debug_as_html_paragraph("Could not find {$filename}");
     }
 
     if ($a_configs === FALSE) {


### PR DESCRIPTION
At the top of the beanweb landing page, the items listed below appear. This pull request aims to fix this issue.

-  Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /var/lib/banwebplus2/resources/globals.php on line 34

-  Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /var/lib/banwebplus2/resources/debug.php on line 4

-  Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /var/lib/banwebplus2/resources/db_query.php on line 67
-  Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /var/lib/banwebplus2/resources/db_query.php on line 73
-  Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /var/lib/banwebplus2/resources/db_query.php on line 85